### PR TITLE
Fix for plot_map and informative error message in calc_haplotypes

### DIFF
--- a/R/haplotypes.R
+++ b/R/haplotypes.R
@@ -96,14 +96,14 @@ calc_haplotypes <- function(x, lg = NULL, type = c("mds", "genome"),
   # Execute the haplotype calculation in parallel
   if(ncpus > 1) {
     os_type <- Sys.info()["sysname"]
-    ncpus <- min(ncpus, parallel:::detectCores())
+    ncpus <- min(ncpus, detectCores())
     if (os_type == "Windows") {
       cl <- makeCluster(ncpus)
       on.exit(stopCluster(cl))
       clusterExport(cl, varlist = c("haplotypeData", "haplotypeFunc", "calc_haplotypes_one"), envir = environment())
       results <- parLapply(cl, haplotypeData, haplotypeFunc)
     } else {
-      results <- parallel::mclapply(haplotypeData, haplotypeFunc, mc.cores = ncpus)
+      results <- mclapply(haplotypeData, haplotypeFunc, mc.cores = ncpus)
     }
   } else {
     # Single-core execution: Use lapply

--- a/R/plot_methods.R
+++ b/R/plot_methods.R
@@ -377,9 +377,9 @@ plot_map <- function(x, lg = 1, type = c("mds", "genome"),
   u <- apply(v[parent,,,drop=FALSE],1,all)
   h <- names(u)[1:2][!u[1:2]]
   if(length(h) == 1)
-    assert_that(u[type], msg = paste(h, "order has not been computed for", parent))
+    assert_that(u[parent], msg = paste(h, "order has not been computed for", parent))
   else
-    assert_that(u[type], msg = paste(h[1], "and", h[2],"orders have not been computed for", parent))
+    assert_that(u[parent], msg = paste(h[1], "and", h[2],"orders have not been computed for", parent))
 
 
   old.par <- par(no.readonly = TRUE)


### PR DESCRIPTION
Dear Marcelo, thanks for the excellent package. While testing the package I noticed a bug for the plot_map() function and the calc_haplotypes() function.

The first one was failing in the assert_that statements because it was mapping to the type argument instead of the parent argument so I made that change.

For the second one I found that the calc_haplotypes() function was not running for me because I didn't run the mapping function for "p1p2" but there was no informative message since I thought that running the mapping() function for "p1" and "p2" was enough. I included an informative message that I hope will help users identify the same issue I faced.

Cheers,
Eduardo